### PR TITLE
Update default.htm

### DIFF
--- a/components/matomojs/default.htm
+++ b/components/matomojs/default.htm
@@ -1,18 +1,18 @@
 {% if __SELF__.remoteUrl and __SELF__.siteId %}
-    <script>
-        var _paq = window._paq = window._paq || [];
-        {% if not __SELF__.useCookies() %}
-        _paq.push(['disableCookies']);
-        {% endif %}
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function() {
-            var u="{{ __SELF__.remoteUrl }}";
-            _paq.push(['setTrackerUrl', u+'matomo.php']);
-            _paq.push(['setSiteId', '{{ __SELF__.siteId }}']);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-        })();
-    </script>
-    <noscript><p><img src="{{ __SELF__.remoteUrl }}matomo.php?idsite={{ __SELF__.siteId }}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<script>
+    var _paq = window._paq = window._paq || [];
+    {% if not __SELF__.useCookies() %}
+    _paq.push(['disableCookies']);
+    {% endif %}
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="{{ __SELF__.remoteUrl }}";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '{{ __SELF__.siteId }}']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<noscript><p><img src="{{ __SELF__.remoteUrl }}matomo.php?idsite={{ __SELF__.siteId }}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
 {% endif %}

--- a/components/matomojs/default.htm
+++ b/components/matomojs/default.htm
@@ -1,4 +1,4 @@
-{% if __SELF__.remoteUrl && __SELF__.siteId %}
+{% if __SELF__.remoteUrl and __SELF__.siteId %}
     <script>
         var _paq = window._paq = window._paq || [];
         {% if not __SELF__.useCookies() %}

--- a/components/matomojs/default.htm
+++ b/components/matomojs/default.htm
@@ -1,16 +1,18 @@
-<script>
-    var _paq = window._paq = window._paq || [];
-    {% if not __SELF__.useCookies() %}
-    _paq.push(['disableCookies']);
-    {% endif %}
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-        var u="{{ __SELF__.remoteUrl }}";
-        _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '{{ __SELF__.siteId }}']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-</script>
-<noscript><p><img src="{{ __SELF__.remoteUrl }}matomo.php?idsite={{ __SELF__.siteId }}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+{% if __SELF__.remoteUrl && __SELF__.siteId %}
+    <script>
+        var _paq = window._paq = window._paq || [];
+        {% if not __SELF__.useCookies() %}
+        _paq.push(['disableCookies']);
+        {% endif %}
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+            var u="{{ __SELF__.remoteUrl }}";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '{{ __SELF__.siteId }}']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        })();
+    </script>
+    <noscript><p><img src="{{ __SELF__.remoteUrl }}matomo.php?idsite={{ __SELF__.siteId }}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+{% endif %}


### PR DESCRIPTION
Add a condition to prevent script errors when matomo settings are empty : 

Hi, I'd like to to suggest a condition test before the insertion of the matomo scripts.
In our work process, Matomo is used in our base project and theme, that we use as starter on every project (thanks by the way ;). But the matomo configuration is filled later, by our teammate when the project is pulled to production. So during the development process, we're getting a js error "matomo.js not found", or we have to remove the component and re-add it later. This is not a huge problem, easily circumvented, but this little test is easy to implement as well, if you don't mind. 